### PR TITLE
use 0.6.0-pre for minimum julia version in REQUIRE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ os:
   - linux
   - osx
 julia:
+  - 0.6
   - nightly
 notifications:
   email: false
-script:
- - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.clone(pwd()); Pkg.build("StandardizedMatrices"); Pkg.test("StandardizedMatrices"; coverage=true)'
+#script:
+# - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+# - julia -e 'Pkg.clone(pwd()); Pkg.build("StandardizedMatrices"); Pkg.test("StandardizedMatrices"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("StandardizedMatrices")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre


### PR DESCRIPTION
`const AVec{T}` and `Base.IndexStyle` won't work on early 0.6.0-dev versions,
so better to stick with the julia-0.5-compatible version of the package there